### PR TITLE
Working GPU implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ OBJ	= $(patsubst %.c,%.o, $(wildcard *.c))
 OBJ	+= $(patsubst %.f90,%.o, $(wildcard *.f90))
 
 clover_leaf: Makefile $(OBJ)
-	$(MPI_F90) $(FLAGS)	$(OBJ) $(LDLIBS) -o clover_leaf
+	$(MPI_C) $(CFLAGS) $(OBJ) $(LDLIBS) -o clover_leaf
 	@echo $(MESSAGE)
 
 include make.deps

--- a/ext_accelerate.c
+++ b/ext_accelerate.c
@@ -48,7 +48,7 @@ void accelerate_kernel_c_(int *xmin,int *xmax,int *ymin,int *ymax,
     double dt = *dbyt;
     int offload = _chunk.offload;
 
-#pragma omp target teams distribute if(offload) 
+#pragma omp target teams distribute if(offload)
 //#pragma omp parallel for
     for (int k = y_min; k <= y_max + 1; k++) 
     {

--- a/ext_map_to_device.c
+++ b/ext_map_to_device.c
@@ -1,0 +1,79 @@
+/*Crown Copyright 2012 AWE.
+ *
+ * This file is part of CloverLeaf.
+ *
+ * CloverLeaf is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * CloverLeaf is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * CloverLeaf. If not, see http://www.gnu.org/licenses/. */
+
+/**
+ *  @brief OpenMP 4.5 target data offloading.
+ *  @author Justin Salmon
+ *  @details Offloads all required data to the target device.
+ */
+
+#include <stdio.h>
+#include "ext_chunk.h"
+
+void map_to_device_c_(int *xmin, int *xmax, int *ymin, int *ymax,
+                      double *density0,
+                      double *density1,
+                      double *energy0,
+                      double *energy1,
+                      double *pressure,
+                      double *viscosity,
+                      double *soundspeed,
+                      double *xvel0,
+                      double *xvel1,
+                      double *yvel0,
+                      double *yvel1,
+                      double *vol_flux_x,
+                      double *vol_flux_y,
+                      double *mass_flux_x,
+                      double *mass_flux_y,
+                      double *work_array1,
+                      double *work_array2,
+                      double *work_array3,
+                      double *work_array4,
+                      double *work_array5,
+                      double *work_array6,
+                      double *work_array7,
+                      double *cellx,
+                      double *celly,
+                      double *vertexx,
+                      double *vertexy,
+                      double *celldx,
+                      double *celldy,
+                      double *vertexdx,
+                      double *vertexdy,
+                      double *xarea,
+                      double *yarea,
+                      double *volume,
+                      int *offload) {
+    int x_min = *xmin;
+    int x_max = *xmax;
+    int y_min = *ymin;
+    int y_max = *ymax;
+    int ideal_offload = *offload && _chunk.offload;
+    int max = x_max * y_max;
+
+ #pragma omp target enter data if(ideal_offload) \
+    map(to: density0[0:max], density1[0:max], energy0[0:max], energy1[0:max]) \
+    map(to: pressure[0:max], viscosity[0:max], soundspeed[0:max], xvel0[0:max]) \
+    map(to: xvel1[0:max], yvel0[0:max], yvel1[0:max], vol_flux_x[0:max]) \
+    map(to: mass_flux_x[0:max], vol_flux_y[0:max], mass_flux_y[0:max]) \
+    map(to: work_array1[0:max], work_array2[0:max], work_array3[0:max]) \
+    map(to: work_array4[0:max], work_array5[0:max], work_array6[0:max]) \
+    map(to: work_array7[0:max], cellx[0:x_max], celly[0:y_max], vertexx[0:x_max]) \
+    map(to: vertexy[0:y_max], celldx[0:x_max], celldy[0:y_max], vertexdx[0:x_max]) \
+    map(to: vertexdy[0:y_max], xarea[0:max], yarea[0:max], volume[0:max])
+}

--- a/make.deps
+++ b/make.deps
@@ -7,6 +7,7 @@ ext_field_summary.o: ext_field_summary.c ftocmacros.h ext_chunk.h
 ext_flux_calc.o: ext_flux_calc.c ftocmacros.h ext_chunk.h
 ext_generate_chunk.o: ext_generate_chunk.c ftocmacros.h
 ext_ideal_gas.o: ext_ideal_gas.c ftocmacros.h ext_chunk.h
+ext_map_to_device.o: ext_map_to_device.c
 ext_initialise_chunk.o: ext_initialise_chunk.c ftocmacros.h
 ext_pack.o: ext_pack.c ftocmacros.h ext_chunk.h
 ext_pdv.o: ext_pdv.c ftocmacros.h ext_chunk.h

--- a/start.f90
+++ b/start.f90
@@ -57,7 +57,7 @@ SUBROUTINE start
   CALL clover_decompose(grid%x_cells,grid%y_cells,left,right,bottom,top)
 
   !create the chunks
-      
+
   chunk%task = parallel%task
 
   IF (use_c_kernels) THEN
@@ -68,7 +68,7 @@ SUBROUTINE start
 
   x_cells = right -left  +1
   y_cells = top   -bottom+1
-      
+
   chunk%left    = left
   chunk%bottom  = bottom
   chunk%right   = right
@@ -111,6 +111,48 @@ SUBROUTINE start
   ! at the end
   profiler_off=profiler_on
   profiler_on=.FALSE.
+
+  ! Map data arrays to device
+  DO tile = 1, tiles_per_chunk
+    CALL map_to_device_c(chunk%tiles(tile)%t_xmin, &
+            chunk%tiles(tile)%t_xmax, &
+            chunk%tiles(tile)%t_ymin, &
+            chunk%tiles(tile)%t_ymax, &
+            chunk%tiles(tile)%field%density0, &
+            chunk%tiles(tile)%field%density1, &
+            chunk%tiles(tile)%field%energy0, &
+            chunk%tiles(tile)%field%energy1, &
+            chunk%tiles(tile)%field%pressure, &
+            chunk%tiles(tile)%field%viscosity, &
+            chunk%tiles(tile)%field%soundspeed, &
+            chunk%tiles(tile)%field%xvel0, &
+            chunk%tiles(tile)%field%xvel1, &
+            chunk%tiles(tile)%field%yvel0, &
+            chunk%tiles(tile)%field%yvel1, &
+            chunk%tiles(tile)%field%vol_flux_x, &
+            chunk%tiles(tile)%field%vol_flux_y, &
+            chunk%tiles(tile)%field%mass_flux_x, &
+            chunk%tiles(tile)%field%mass_flux_y, &
+            chunk%tiles(tile)%field%work_array1, &
+            chunk%tiles(tile)%field%work_array2, &
+            chunk%tiles(tile)%field%work_array3, &
+            chunk%tiles(tile)%field%work_array4, &
+            chunk%tiles(tile)%field%work_array5, &
+            chunk%tiles(tile)%field%work_array6, &
+            chunk%tiles(tile)%field%work_array7, &
+            chunk%tiles(tile)%field%cellx, &
+            chunk%tiles(tile)%field%celly, &
+            chunk%tiles(tile)%field%vertexx, &
+            chunk%tiles(tile)%field%vertexy, &
+            chunk%tiles(tile)%field%celldx, &
+            chunk%tiles(tile)%field%celldy, &
+            chunk%tiles(tile)%field%vertexdx, &
+            chunk%tiles(tile)%field%vertexdy, &
+            chunk%tiles(tile)%field%xarea, &
+            chunk%tiles(tile)%field%yarea, &
+            chunk%tiles(tile)%field%volume, &
+            1)
+  END DO
 
   DO tile = 1, tiles_per_chunk
     CALL ideal_gas(tile,.FALSE.,0)


### PR DESCRIPTION
This adds basic support for offloading to a GPU wih OpenMP 4.5. It has been tested on a
K20 on BCP3, compiled with llvm trunk (built from HEAD on 15/03/2019).

@mattmartineau, would you be able to give this a quick sanity check?

Notes:
- I haven't tested to see if it still works on the KNL that this was originally built for
- I had to change the makefile to link with `mpicc` rather than `mpifort`
- Interestingly, adding `parallel for` after `target teams distribute` made things slower
- I haven't `collapse`d the loops, I tried this and it made virtually no difference

Signed-off-by: Justin Lewis Salmon <justin.lewis.salmon@gmail.com>