### PR TITLE
Fix build and run errors on Cray

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ COMPILER	= INTEL
 MODE	 	= offload
 MPI_F90		= mpiifort
 MPI_C		= mpiicc
+MPI_LD		= $(MPI_F90)
 CPROFILER   = no
 
 ifeq ($(MODE), native)
@@ -133,12 +134,13 @@ endif
 
 FLAGS=$(FLAGS_$(COMPILER)) $(OMP) $(I3E) $(OPTIONS) $(MIC)
 CFLAGS=$(CFLAGS_$(COMPILER)) $(OMP) $(I3E) $(C_OPTIONS) $(MIC) -c
+LDFLAGS=$(FLAGS)
 
 OBJ	= $(patsubst %.c,%.o, $(wildcard *.c))
 OBJ	+= $(patsubst %.f90,%.o, $(wildcard *.f90))
 
 clover_leaf: Makefile $(OBJ)
-	$(MPI_C) $(CFLAGS) $(OBJ) $(LDLIBS) -o clover_leaf
+	$(MPI_LD) $(LDFLAGS) $(OBJ) $(LDLIBS) -o clover_leaf
 	@echo $(MESSAGE)
 
 include make.deps

--- a/ext_map_to_device.c
+++ b/ext_map_to_device.c
@@ -78,3 +78,20 @@ void map_to_device_c_(int *xmin, int *xmax, int *ymin, int *ymax,
     map(to: vertexdy[0:y_max+5], xarea[0:(x_max+5)*(y_max+4)], yarea[0:(x_max+4)*(y_max+5)], volume[0:(x_max+4)*(y_max+4)])
 }
 
+void update_from_device_c_(int *xmin, int *xmax, int *ymin, int *ymax,
+                      double *density0,
+                      double *energy0,
+                      double *pressure,
+                      double *xvel0,
+                      double *yvel0)
+{
+    int x_min = *xmin;
+    int x_max = *xmax;
+    int y_min = *ymin;
+    int y_max = *ymax;
+
+#pragma omp target update if(_chunk.offload) \
+    from(density0[0:(x_max+4)*(y_max+4)], energy0[0:(x_max+4)*(y_max+4)], pressure[0:(x_max+4)*(y_max+4)]) \
+    from(xvel0[0:(x_max+5)*(y_max+5)], yvel0[0:(x_max+5)*(y_max+5)])
+}
+

--- a/ext_map_to_device.c
+++ b/ext_map_to_device.c
@@ -67,13 +67,14 @@ void map_to_device_c_(int *xmin, int *xmax, int *ymin, int *ymax,
     int max = x_max * y_max;
 
  #pragma omp target enter data if(ideal_offload) \
-    map(to: density0[0:max], density1[0:max], energy0[0:max], energy1[0:max]) \
-    map(to: pressure[0:max], viscosity[0:max], soundspeed[0:max], xvel0[0:max]) \
-    map(to: xvel1[0:max], yvel0[0:max], yvel1[0:max], vol_flux_x[0:max]) \
-    map(to: mass_flux_x[0:max], vol_flux_y[0:max], mass_flux_y[0:max]) \
-    map(to: work_array1[0:max], work_array2[0:max], work_array3[0:max]) \
-    map(to: work_array4[0:max], work_array5[0:max], work_array6[0:max]) \
-    map(to: work_array7[0:max], cellx[0:x_max], celly[0:y_max], vertexx[0:x_max]) \
-    map(to: vertexy[0:y_max], celldx[0:x_max], celldy[0:y_max], vertexdx[0:x_max]) \
-    map(to: vertexdy[0:y_max], xarea[0:max], yarea[0:max], volume[0:max])
+    map(to: density0[0:(x_max+4)*(y_max+4)], density1[0:(x_max+4)*(y_max+4)], energy0[0:(x_max+4)*(y_max+4)], energy1[0:(x_max+4)*(y_max+4)]) \
+    map(to: pressure[0:(x_max+4)*(y_max+4)], viscosity[0:(x_max+4)*(y_max+4)], soundspeed[0:(x_max+4)*(y_max+4)], xvel0[0:(x_max+5)*(y_max+5)]) \
+    map(to: xvel1[0:(x_max+5)*(y_max+5)], yvel0[0:(x_max+5)*(y_max+5)], yvel1[0:(x_max+5)*(y_max+5)], vol_flux_x[0:(x_max+5)*(y_max+4)]) \
+    map(to: mass_flux_x[0:(x_max+5)*(y_max+4)], vol_flux_y[0:(x_max+4)*(y_max+5)], mass_flux_y[0:(x_max+4)*(y_max+5)]) \
+    map(to: work_array1[0:(x_max+5)*(y_max+5)], work_array2[0:(x_max+5)*(y_max+5)], work_array3[0:(x_max+5)*(y_max+5)]) \
+    map(to: work_array4[0:(x_max+5)*(y_max+5)], work_array5[0:(x_max+5)*(y_max+5)], work_array6[0:(x_max+5)*(y_max+5)]) \
+    map(to: work_array7[0:(x_max+5)*(y_max+5)], cellx[0:x_max+4], celly[0:y_max+4], vertexx[0:x_max+5]) \
+    map(to: vertexy[0:y_max+5], celldx[0:x_max+4], celldy[0:y_max+4], vertexdx[0:x_max+5]) \
+    map(to: vertexdy[0:y_max+5], xarea[0:(x_max+5)*(y_max+4)], yarea[0:(x_max+4)*(y_max+5)], volume[0:(x_max+4)*(y_max+4)])
 }
+

--- a/hydro.f90
+++ b/hydro.f90
@@ -168,6 +168,10 @@ SUBROUTINE hydro_step(xmin, xmax, ymin, ymax, density0, density1, &
 
     IF(time+g_small.GT.end_time.OR.step.GE.end_step) THEN
 
+        !$OMP TARGET UPDATE IF(g_offload)&
+        !$OMP from(density0, energy0, pressure) &
+        !$OMP from(xvel0, yvel0)
+
         complete=.TRUE.
         CALL field_summary()
         IF(visit_frequency.NE.0) CALL visit()

--- a/hydro.f90
+++ b/hydro.f90
@@ -168,9 +168,11 @@ SUBROUTINE hydro_step(xmin, xmax, ymin, ymax, density0, density1, &
 
     IF(time+g_small.GT.end_time.OR.step.GE.end_step) THEN
 
-        !$OMP TARGET UPDATE IF(g_offload)&
-        !$OMP from(density0, energy0, pressure) &
-        !$OMP from(xvel0, yvel0)
+        ! !$OMP TARGET UPDATE IF(g_offload)&
+        ! !$OMP from(density0, energy0, pressure) &
+        ! !$OMP from(xvel0, yvel0)
+        CALL update_from_device_c(xmin, xmax, ymin, ymax, &
+            density0, energy0, pressure, xvel0, yvel0)
 
         complete=.TRUE.
         CALL field_summary()


### PR DESCRIPTION
This PR contains the changes to the code made for the DoE P3 benchmarks. It addresses the following main issues:

- The build was broken with the default Makefile because `-c` was passed to the linker in the final step without any new files. This now works as expected with `COMPILER=CRAY MPI_C=cc MPI_F90=ftn`. The `MPI_LD` and `LDFLAGS` variables were added for easier build configuration in the future.
- The code would crash at run time because arrays were only partially copied to the device, not respecting the re-indexing in `hydro.f90`. The `target enter data` directive has been updated with the full extent of each array.
- Solution validation would fail because the required was not copied back to the host before the checking procedure. This was solved with a `target update` directive.